### PR TITLE
Make scater-scripts work with bioconductor-scater_1.10.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
       conda config --add channels conda-forge;
       conda config --add channels bioconda;
 
-      conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION r-base r-optparse libpng r-cairo r-workflowscriptscommon bioconductor-scater=1.8.4 bioconductor-singlecellexperiment-scripts dropletutils-scripts r-rtsne;
+      conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION r-base r-optparse libpng r-cairo r-workflowscriptscommon bioconductor-scater=1.10.0 bioconductor-singlecellexperiment-scripts dropletutils-scripts r-rtsne;
     fi
 
 install:

--- a/bioconductor-scater-scripts-post-install-tests.bats
+++ b/bioconductor-scater-scripts-post-install-tests.bats
@@ -88,7 +88,7 @@
         skip "$use_existing_outputs $filtered_singlecellexperiment_object exists and use_existing_outputs is set to 'true'"
     fi
 
-    run rm -f $filtered_singlecellexperiment_object && scater-filter.R -i $qc_singlecellexperiment_object -s total_counts,total_features -l $min_cell_total_counts,$min_cell_total_features -t n_cells_counts -m $min_feature_n_cells_counts -o $filtered_singlecellexperiment_object -u $cell_filter_matrix -v $feature_filter_matrix
+    run rm -f $filtered_singlecellexperiment_object && scater-filter.R -i $qc_singlecellexperiment_object -s $cell_metrics -l $min_cell_total_counts,$min_cell_total_features -t $gene_metrics -m $min_feature_n_cells_counts -o $filtered_singlecellexperiment_object -u $cell_filter_matrix -v $feature_filter_matrix
     
     echo "status = ${status}"
     echo "output = ${output}"

--- a/bioconductor-scater-scripts-post-install-tests.sh
+++ b/bioconductor-scater-scripts-post-install-tests.sh
@@ -88,6 +88,8 @@ export outliers_file="$output_dir/outliers.txt"
 ### Workflow parameters
 
 export col_names=TRUE
+export cell_metrics=total_counts,total_features_by_counts
+export gene_metrics=n_cells_by_counts
 export min_cell_total_counts=500
 export min_cell_total_features=50
 export min_feature_n_cells_counts=10


### PR DESCRIPTION
bioconductor-scater_1.10 introduces changes to qc metric names which breaks current test code.
Change to new qc metric names in the test scripts is sufficient. No change to
scripts themselves is required.